### PR TITLE
Add query profile type

### DIFF
--- a/src/main/application/search/query-profiles/default.xml
+++ b/src/main/application/search/query-profiles/default.xml
@@ -1,3 +1,5 @@
+<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+
 <query-profile id="default">
  <field name="presentation.timing">true</field>
 </query-profile>

--- a/src/main/application/search/query-profiles/types/default.xml
+++ b/src/main/application/search/query-profiles/types/default.xml
@@ -1,0 +1,10 @@
+<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+
+<query-profile-type id="default" inherits="native">
+    <field name="ranking.features.query(contentsWeight)" type="float" />
+    <field name="ranking.features.query(titleWeight)" type="float" />
+    <field name="ranking.features.query(contentWeight)" type="float" />
+    <field name="ranking.features.query(gramTitleWeight)" type="float" />
+    <field name="ranking.features.query(gramContentWeight)" type="float" />
+    <field name="ranking.features.query(q_term_count)" type="integer" />
+</query-profile-type>

--- a/src/main/application/search/query-profiles/types/links.xml
+++ b/src/main/application/search/query-profiles/types/links.xml
@@ -3,4 +3,3 @@
 <query-profile-type id="links" inherits="native">
     <field name="ranking.features.query(links)" type="tensor&lt;float&gt;(links{})" />
 </query-profile-type>
-


### PR DESCRIPTION
I am not sure if this is right, so I want to improve the vespa doc on this as well

https://github.com/vespa-cloud/vespa-documentation-search/blob/main/src/main/application/schemas/doc.sd#L99 :

````
        rank-properties {
            $titleWeight: 20.0
            $contentWeight: 10.0
            $gramTitleWeight: 2.0
            $gramContentWeight: 1.0
        }
````

I seem to remember the $ syntax is legacy, but not sure

https://docs.vespa.ai/en/reference/schema-reference.html#rank-properties does not point to an example with query features