### PR TITLE
doc search updates

### DIFF
--- a/src/main/application/schemas/doc.sd
+++ b/src/main/application/schemas/doc.sd
@@ -5,21 +5,19 @@ schema doc {
     }
     
     field gram_title type string {
-        indexing: input title | index | summary
+        indexing: input title | index
         match {
             gram
             gram-size: 3
         }
-        summary: dynamic
     }
 
     field gram_content type string {
-        indexing: input content | index | summary
+        indexing: input content | index
         match {
             gram
             gram-size: 3
         }
-        summary: dynamic
     }
 
     document doc {
@@ -110,7 +108,7 @@ schema doc {
                 + query(pathWeight) * bm25(path)
             }
         }
-        summary-features {
+        match-features {
             query(titleWeight)
             query(contentWeight)
             query(headersWeight)

--- a/src/main/application/schemas/term.sd
+++ b/src/main/application/schemas/term.sd
@@ -28,7 +28,13 @@ schema term {
             attribute: fast-search
         }
         
-    } 
+    }
+
+    document-summary suggestion {
+        summary term type string {
+            source: term
+        }
+    }
 
     fieldset default {
         fields: term, terms

--- a/src/main/application/search/query-profiles/default.xml
+++ b/src/main/application/search/query-profiles/default.xml
@@ -2,4 +2,5 @@
 
 <query-profile id="default">
  <field name="presentation.timing">true</field>
+ <field name="model.language">true</field>
 </query-profile>

--- a/src/main/application/search/query-profiles/default.xml
+++ b/src/main/application/search/query-profiles/default.xml
@@ -2,5 +2,5 @@
 
 <query-profile id="default">
  <field name="presentation.timing">true</field>
- <field name="model.language">true</field>
+ <field name="model.language">en</field>
 </query-profile>

--- a/src/main/application/services.xml
+++ b/src/main/application/services.xml
@@ -5,7 +5,6 @@
         <document-processing>
             <chain id="default">
                 <documentprocessor id="ai.vespa.cloud.docsearch.OutLinksDocumentProcessor" bundle="vespacloud-docsearch"/>
-                <documentprocessor id="ai.vespa.cloud.docsearch.QueryDocumentProcessor" bundle="vespacloud-docsearch"/>
             </chain>
         </document-processing>
         <search>

--- a/src/main/java/ai/vespa/cloud/docsearch/DocumentationSearcher.java
+++ b/src/main/java/ai/vespa/cloud/docsearch/DocumentationSearcher.java
@@ -4,6 +4,9 @@ package ai.vespa.cloud.docsearch;
 import com.yahoo.prelude.query.PrefixItem;
 import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordItem;
+import com.yahoo.prelude.query.FuzzyItem;
+import com.yahoo.prelude.query.OrItem;
+import com.yahoo.prelude.query.Item;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
@@ -12,18 +15,22 @@ import com.yahoo.search.searchchain.Execution;
 
 /**
  * Searches for suggestions, and returns a result containing both the suggestions
- * and the documents matching the most relevant suggestion. Return up to 5 suggestions and up to 10 document results.
- * This is activated by passing the property term, containing a (partially typed)
+ * and the documents matching the most relevant suggestion. Return up to 10 suggestions and up to 10 document results.
+ *
+ * This searcher is activated by passing the property term, containing a (partially typed)
  * user query string.
  */
 public class DocumentationSearcher extends Searcher {
+
+    private static final String SUGGESTION_SUMMARY = "suggestion";
+    private static final String SUGGESTION_RANK_PROFILE = "term_rank";
 
     @Override
     public Result search(Query query, Execution execution) {
         String userQuery = query.properties().getString("term");
         if (userQuery == null) return execution.search(query);
 
-        Result suggestions = getSuggestions(userQuery, execution);
+        Result suggestions = getSuggestions(userQuery, execution, query);
         query.getModel().setRestrict("doc");
         WeakAndItem weakAndItem = new WeakAndItem();
         for (String term: suggestions.getHitCount() > 0 ? suggestedTerms(suggestions) : userQuery.split(" "))
@@ -31,27 +38,48 @@ public class DocumentationSearcher extends Searcher {
         query.getModel().getQueryTree().setRoot(weakAndItem);
         query.getRanking().setProfile("documentation");
         Result result = execution.search(query);
-        result.getQuery().setHits(15);
+        result.getQuery().setHits(20);
         result.hits().addAll(suggestions.hits().asList());
         return result;
     }
 
-    private Result getSuggestions(String userQuery, Execution execution) {
+    private Result getSuggestions(String userQuery, Execution execution, Query originalQuery) {
         Query query = new Query();
-        query.setHits(5);
+        query.getPresentation().setSummary(SUGGESTION_SUMMARY);
+        originalQuery.attachContext(query);
+        query.setHits(10);
         query.getModel().setRestrict("term");
-        query.getModel().getQueryTree().setRoot(new PrefixItem(userQuery, "default"));
-        query.getRanking().setProfile("term_rank");
+        query.getRanking().setProfile(SUGGESTION_RANK_PROFILE);
+
+        Item suggestionQuery = buildSuggestionQueryTree(userQuery);
+        query.getModel().getQueryTree().setRoot(suggestionQuery);
+
         Result suggestionResult = execution.search(query);
-        execution.fill(suggestionResult);
+        execution.fill(suggestionResult, SUGGESTION_SUMMARY);
         return suggestionResult;
+    }
+
+    private Item buildSuggestionQueryTree(String userQuery) {
+        PrefixItem prefix = new PrefixItem(userQuery, "default");
+        int maxDistance = 1;
+        int length = userQuery.length();
+        // Allow higher distance for longer queries
+        if(length > 6)
+            maxDistance = 2;
+        else if(length > 12)
+            maxDistance = 3;
+        FuzzyItem fuzzyItem = new FuzzyItem("terms",
+                true, userQuery, maxDistance,2);
+        OrItem orItem = new OrItem();
+        orItem.addItem(prefix);
+        orItem.addItem(fuzzyItem);
+        return orItem;
     }
 
     private String[] suggestedTerms(Result suggestionResult) {
         Hit topHit = suggestionResult.hits().get(0);
-        if (topHit.fields().get("term") == null)
+        if (topHit.getField("term") == null)
             throw new IllegalStateException("Suggestion result unexpectedly missing 'term' field");
         return topHit.getField("term").toString().split(" ");
     }
-
 }


### PR DESCRIPTION
- Remove the document processor, which filters suggestions 
- Add fuzzy matching for query suggestions to handle typos. Dynamic edit distance based on input length
- Avoid dynamic summaries for redundant fields 
- Don't use default summary for fetching summaries, avoiding disk 
- Use match features instead of summary features to avoid one extra call to the backend

Overall, this reduces the overall /search?term= API latency by 3x