### PR TITLE
Use 32Gb disk for the content cluster documentation

### DIFF
--- a/src/main/application/services.xml
+++ b/src/main/application/services.xml
@@ -59,7 +59,7 @@
             <document mode="index" type="purchase"/>
         </documents>
         <nodes count="2">
-            <resources vcpu="2" memory="8Gb" disk="10Gb" architecture="x86_64" deploy:instance="enclave" />
+            <resources vcpu="2" memory="8Gb" disk="32Gb" architecture="x86_64" deploy:instance="enclave" />
         </nodes>
     </content>
 


### PR DESCRIPTION
To clear the last warning
`Requested disk (10.0Gb) in cluster 'documentation' is not large enough to fit core/heap dumps. Minimum recommended disk resources is 2x memory for containers and 3x memory for content`