### PR TITLE
To be used in summaries

### DIFF
--- a/src/main/application/schemas/paragraph.sd
+++ b/src/main/application/schemas/paragraph.sd
@@ -50,6 +50,10 @@ schema paragraph {
         field last_updated type int {
             indexing: summary | attribute
         }
+
+        field selfhosted type bool {
+            indexing: summary | attribute
+        }
     }
 
     field questions_exact type array<string> {


### PR DESCRIPTION
- when generating the paragraphs, we will know if the document is for self-hosted or not (this is WIP)
- we can use this flag to mark the result accordingly