### PR TITLE
Improve ranking

### DIFF
--- a/eval/evaluate_ranking.py
+++ b/eval/evaluate_ranking.py
@@ -1,0 +1,74 @@
+from calendar import c
+import ir_measures
+from numpy import c_
+import requests
+from ir_measures import calc_aggregate, nDCG, ScoredDoc, Success
+import ir_measures
+from enum import Enum
+from typing import List
+
+
+
+def parse_vespa_response(response:dict, qid:str) -> List[ScoredDoc]:
+    result = []
+    hits = response['root'].get('children',[])
+    for hit in hits:
+      doc_id = hit['fields']['path']
+      relevance = hit['relevance']
+      result.append(ScoredDoc(qid, doc_id, relevance))
+    return result
+
+def search(query:str, qid:str, ranking:str, 
+           hits=10) -> List[ScoredDoc]:
+    
+    query_request = {
+        'query': query,
+        'ranking.profile': ranking,
+        'queryProfile': 'llmsearch',
+        'hits' : hits, 
+        'filters': '+namespace:open-p'
+    }
+    response = requests.post("http://localhost:8080/search/", json=query_request)
+    if response.ok:
+        return parse_vespa_response(response.json(), qid)
+    else:
+      print("Search request failed with response " + str(response.json()))
+      return []
+
+def main():
+  with open("qrels.tsv") as f:
+    qrels = []
+    queries = {}
+    with open("qrels.tsv") as f:
+      for line in f:
+        qid, query, doc_id, rel = line.strip().split("\t")
+        rel = ir_measures.Qrel(qid, doc_id, int(rel))
+        qrels.append(rel)
+        queries[query] = qid
+
+  a_results = []
+  b_results = []
+  c_results = []
+  d_results = []
+  e_results = []
+  metrics = [nDCG@10]
+  for query_text, qid in queries.items():
+    a_results.extend(search(query_text, qid, "hybrid"))
+    b_results.extend(search(query_text, qid, "hybrid2"))
+    c_results.extend(search(query_text, qid, "hybrid3"))
+    d_results.extend(search(query_text, qid, "bm25"))
+    e_results.extend(search(query_text, qid, "semantic"))
+
+  a = calc_aggregate(metrics, qrels, a_results)
+  b = calc_aggregate(metrics, qrels, b_results)
+  c = calc_aggregate(metrics, qrels, c_results)
+  d = calc_aggregate(metrics, qrels, d_results)
+  e = calc_aggregate(metrics, qrels, e_results)
+  print("Hybrid {}".format(a))
+  print("Hybrid2 {}".format(b))
+  print("Hybrid3 {}".format(c))
+  print("BM25 {}".format(d))
+  print("Semantic {}".format(e))  
+
+if __name__ == "__main__":
+    main()

--- a/eval/qrels.tsv
+++ b/eval/qrels.tsv
@@ -1,0 +1,90 @@
+VESPA_1	perf record proton	/en/performance/profiling.html#cpu-profiling-using-perf	2
+VESPA_1	perf record proton	en/proton.html#proton-maintenance-jobs	0
+VESPA_1	perf record proton	/en/proton.html#	0
+VESPA_1	perf record proton	/en/performance/profiling.html#container-privileges	1
+VESPA_2	how to configure ranking?	/en/getting-started-ranking.html#	2
+VESPA_2	how to configure ranking?	/en/ranking.html#	2
+VESPA_2	how to configure ranking?	/en/reference/ranking-expressions.html	2
+VESPA_3	what is global phase ranking?	/en/reference/schema-reference.html#global-phase	2
+VESPA_3	what is global phase ranking?	/en/phased-ranking.html#	2
+VESPA_3	what is global phase ranking?	/en/phased-ranking.html#using-a-global-phase-expression	2
+VESPA_3	what is global phase ranking?	/en/reference/query-api-reference.html#ranking.globalphase.rerankcount	2
+VESPA_3	what is global phase ranking?	/en/reranking-in-searcher.html#	2
+VESPA_4	how to write a searcher?	/en/searcher-development.html#testing-a-searcher	0
+VESPA_4	how to write a searcher?	/en/searcher-development.html#	1
+VESPA_4	how to write a searcher?	en/searcher-development.html#searchers	2
+VESPA_4	how to write a searcher?	en/searcher-development.html#writing-a-searcher	2
+VESPA_4	how to write a searcher?	/en/content/consistency.html#write-durability-and-consistency	0
+VESPA_5	gguf	/en/llms-local.html#valid-llm-models	2
+VESPA_6	is there a max field length?	/en/reference/schema-reference.html#max-length	2
+VESPA_6	is there a max field length?	/en/schemas.html#field-size	2
+VESPA_6	is there a max field length?	/en/reference/schema-reference.html#max-occurrences	1
+VESPA_6	is there a max field length?	/en/reference/bm25.html#ranking-function	1
+VESPA_7	yql grammar 	/en/reference/query-language-reference.html#grammar	2
+VESPA_7	yql grammar 	/en/reference/query-language-reference.html#userinput	1
+VESPA_7	yql grammar 	/en/reference/query-language-reference.html#defaultindex	1
+VESPA_8	tensor ebnf 	/en/reference/tensor.html#general-literal-form	2
+VESPA_9	what is fast-search	/en/attributes.html#fast-search	2
+VESPA_9	what is fast-search	/en/performance/practical-search-performance-guide.html#searching-attribute-fields-using-fast-search	2
+VESPA_9	what is fast-search	/en/performance/feature-tuning.html#when-to-use-fast-search-for-attribute-fields	2
+VESPA_9	what is fast-search	/en/attributes.html#index-structures	2
+VESPA_10	default match mode for string 	/en/vespa8-release-notes.html#strict-mode-enabled-by-default	0
+VESPA_10	default match mode for string 	/en/schemas.html#match	1
+VESPA_10	default match mode for string 	/en/performance/feature-tuning.html#indexing-uuids	1
+VESPA_10	default match mode for string 	/en/reference/schema-reference.html#match	2
+VESPA_11	what is min-redundancy?	/en/reference/services-content.html#min-redundancy	2
+VESPA_11	what is min-redundancy?	/en/performance/sizing-examples.html#flat-distribution	1
+VESPA_11	what is min-redundancy?	/en/reference/ranking-expressions.html#min-t	0
+VESPA_12	onnx-intra-threads	/en/reference/schema-reference.html#onnx-model	2
+VESPA_12	onnx-intra-threads	/en/stateless-model-evaluation.html#onnx-inference-options	2
+VESPA_12	onnx-intra-threads	/en/onnx.html#importing-onnx-model-files	0
+VESPA_12	onnx-intra-threads	/en/reference/embedding-reference.html#embedder-onnx-reference-config	2
+VESPA_13	how to normalize bm25 	/en/reference/bm25.html#"	1
+VESPA_13	how to normalize bm25 	/en/reference/bm25.html#ranking-function	1
+VESPA_13	how to normalize bm25 	/en/reference/schema-reference.html#normalizing	0
+VESPA_14	configure java gc parameters	/en/reference/default-set-metrics-reference.html#jdisc_gc_ms	0
+VESPA_14	configure java gc parameters	/en/reference/services-container.html#nodes.jvm-gc-options	2
+VESPA_14	configure java gc parameters	/en/reference/services-admin.html#logserver.jvm-gc-options	2
+VESPA_14	configure java gc parameters	/en/reference/distributor-metrics-reference.html#vds_idealstate_max_observed_time_since_last_gc_sec	0
+VESPA_15	innerproduct metric	/en/reference/schema-reference.html#prenormalized-angular	2
+VESPA_16	colbert max q length	/en/embedding.html#colbert-embedder	1
+VESPA_16	colbert max q length	/en/reference/embedding-reference.html#colbert-embedder	2
+VESPA_17	colbert maxsimilarity	/en/embedding.html#colbert-ranking	2
+VESPA_18	what is services.xml	/en/reference/services.html#	2
+VESPA_18	what is services.xml	/en/application-packages.html#services.xml	2
+VESPA_18	what is services.xml	/en/tutorials/text-search.html#services-specification	2
+VESPA_19	what is vespa	/en/features.html#what-is-vespa	2
+VESPA_20	how to set vespa deploy target	/en/reference/vespa-cli/vespa_config_set.html#set-the-target-to-vespa-cloud	2
+VESPA_20	how to set vespa deploy target	/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-deploy	0
+VESPA_21	getting started with vespa	/en/getting-started.html#	2
+VESPA_21	getting started with vespa	/en/performance/valgrind.html#start-vespa-using-valgrind	0
+VESPA_21	getting started with vespa	/en/operations-selfhosted/configuration-server.html#start-sequence	0
+VESPA_21	getting started with vespa	/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-start-configserver	0
+VESPA_21	getting started with vespa	/en/operations-selfhosted/vespa-cmdline-tools.html#vespa-start-services	0
+VESPA_21	getting started with vespa	/en/operations-selfhosted/docker-containers.html#start-vespa-container-with-vespa-user	0
+VESPA_21	getting started with vespa	/en/vespa-quick-start-java.html#next-steps	1
+VESPA_21	getting started with vespa	en/vespa-quick-start.html#	2
+VESPA_22	k8 vespa	/en/features.html#what-is-vespa	0
+VESPA_22	k8 vespa	/en/operations-selfhosted/using-kubernetes-with-vespa.html#	2
+VESPA_22	k8 vespa	/en/operations-selfhosted/using-kubernetes-with-vespa.html#singlenode-quickstart-with-minikube	1
+VESPA_22	k8 vespa	/en/getting-started.html#	1
+VESPA_23	mixtral context length	/en/reference/schema-reference.html#max-token-length	0
+VESPA_23	mixtral context length	/en/llms-local.html#valid-llm-models	1
+VESPA_23	mixtral context length	/en/llms-local.html#local-llm-configuration	2
+VESPA_24	xgbost trees	/en/xgboost.html#ranking-with-xgboost-models	2
+VESPA_24	xgbost trees	/en/xgboost.html#xgboost-models	2
+VESPA_24	xgbost trees	/en/lightgbm.html#	1
+VESPA_24	xgbost trees	/en/annotations.html#manipulating-a-span-tree	0
+VESPA_25	how to tune post filter thresholds	/en/reference/schema-reference.html#post-filter-threshold	2
+VESPA_25	how to tune post filter thresholds	/en/nearest-neighbor-search-guide.html#controlling-filter-behavior	2
+VESPA_25	how to tune post filter thresholds	/en/approximate-nn-hnsw.html#combining-approximate-nearest-neighbor-search-with-filters	1
+VESPA_25	how to tune post filter thresholds	/en/tutorials/news-5-recommendation.html#filtering	1
+VESPA_25	how to tune post filter thresholds	/en/reference/query-api-reference.html#ranking.matching.postfilterthreshold	2
+VESPA_25	how to tune post filter thresholds	/en/reference/schema-reference.html#approximate-threshold	1
+VESPA_25	how to tune post filter thresholds	/en/reference/services-content.html#tuning	0
+VESPA_25	how to use more threads per query	/en/performance/practical-search-performance-guide.html#multithreaded-search-and-ranking	2
+VESPA_26	how to use more threads per query	/en/performance/sizing-search.html#reduce-latency-with-multi-threaded-per-search-execution	2
+VESPA_26	how to use more threads per query	/en/reference/schema-reference.html#num-threads-per-search	2
+VESPA_26	how to use more threads per query	/en/performance/sizing-search.html#	1
+VESPA_26	how to use more threads per query	/en/reference/query-api-reference.html#ranking.matching.numthreadspersearch	2
+VESPA_26	how to use more threads per query	/en/reference/query-api-reference.html#ranking.matching	1

--- a/eval/qrels.tsv
+++ b/eval/qrels.tsv
@@ -39,7 +39,7 @@ VESPA_12	onnx-intra-threads	/en/reference/schema-reference.html#onnx-model	2
 VESPA_12	onnx-intra-threads	/en/stateless-model-evaluation.html#onnx-inference-options	2
 VESPA_12	onnx-intra-threads	/en/onnx.html#importing-onnx-model-files	0
 VESPA_12	onnx-intra-threads	/en/reference/embedding-reference.html#embedder-onnx-reference-config	2
-VESPA_13	how to normalize bm25 	/en/reference/bm25.html#"	1
+VESPA_13	how to normalize bm25 	/en/reference/bm25.html#	1
 VESPA_13	how to normalize bm25 	/en/reference/bm25.html#ranking-function	1
 VESPA_13	how to normalize bm25 	/en/reference/schema-reference.html#normalizing	0
 VESPA_14	configure java gc parameters	/en/reference/default-set-metrics-reference.html#jdisc_gc_ms	0

--- a/src/main/application/schemas/paragraph.sd
+++ b/src/main/application/schemas/paragraph.sd
@@ -81,14 +81,20 @@ schema paragraph {
 
     document-summary short-summary {
         from-disk
-        summary title type string {}
-        summary content type string {}
-        summary path type string {}
-        summary doc_id type string {}
+        summary title {}
+        summary content {}
+        summary path {}
+        summary doc_id {}
     }
 
     fieldset default {
         fields: title, content, path, questions
+    }
+
+    rank-profile bm25 {
+        first-phase {
+            expression: bm25(title) + bm25(content) + bm25(path)
+        }
     }
 
     rank-profile semantic inherits default {
@@ -121,4 +127,75 @@ schema paragraph {
         }
         match-features: keywords semantic semantic_question nativeRank(title) nativeRank(content) nativeRank(path) elementCompleteness(questions).completeness elementCompleteness(questions_exact).completeness
     }
+
+     rank-profile hybrid2 {
+        inputs {
+            query(q) tensor<float>(x[384])
+            query(semantic_weight) double: 0.6
+        }
+        function scale(val) {
+            expression: 2*atan(val/4)/(3.14159)
+        }
+
+        function scaled_bm25_content() {
+            expression: scale(bm25(content))
+        }
+
+        function scaled_bm25_title() {
+            expression: scale(bm25(title))
+        }
+
+        function scaled_bm25_path() {
+            expression: scale(bm25(path))
+        }
+
+        function combined_bm25() {
+            expression: 0.3*scale(bm25(title)) + 0.6*scale(bm25(content)) + 0.1*scale(bm25(path))
+        }
+
+         function semantic_content() {
+            expression: cos(distance(field, embedding))
+         }
+
+         function semantic_question() {
+            expression: max(cos(distance(field, question_embedding)),0)
+         }
+
+         function semantic_combined() {
+            expression: 0.5*semantic_content + 0.5*semantic_question
+         }
+
+         function keywords() {
+            expression: ( 0.8*combined_bm25  + 0.1*elementCompleteness(questions).completeness) + 0.1*elementCompleteness(questions_exact).completeness
+         }
+
+         first-phase {
+            expression {
+                query(semantic_weight)*semantic_combined + (1 - query(semantic_weight))*keywords
+            }
+            rank-score-drop-limit: 0.0
+         }
+         match-features {
+            queryTermCount
+            keywords
+            bm25(title)
+            scaled_bm25_title
+            bm25(content)
+            scaled_bm25_content
+            bm25(path)
+            scaled_bm25_path
+            combined_bm25
+            semantic_question
+            semantic_content
+            semantic_combined
+            elementCompleteness(questions).completeness
+            elementCompleteness(questions_exact).completeness
+         }
+     }
+
+     rank-profile hybrid3 inherits hybrid2 {
+        global-phase {
+            expression: reciprocal_rank(semantic_combined) + reciprocal_rank(keywords)
+        }
+     }
 }

--- a/src/main/application/schemas/term.sd
+++ b/src/main/application/schemas/term.sd
@@ -45,18 +45,10 @@ schema term {
     }
 
     document-summary suggestion {
-        summary term type string {
-            source: term
-        }
-        summary namespace type string {
-            source: namespace
-        }
-        summary url type string {
-            source: url
-        }
-        summary type type string {
-            source: type
-        }
+        summary term {}
+        summary namespace {}
+        summary url {}
+        summary type {}
     }
 
     fieldset default {

--- a/src/main/application/search/query-profiles/llmsearch.xml
+++ b/src/main/application/search/query-profiles/llmsearch.xml
@@ -2,10 +2,8 @@
 <query-profile id="llmsearch">
  <field name="searchChain">llmsearch</field>
  <field name="model.restrict">paragraph</field>
- <field name="ranking.profile">hybrid</field>
- <field name="input.query(sw)">0.2</field>
- <field name="input.query(ew)">0.0</field>
- <field name="hits">15</field>
+ <field name="ranking.profile">hybrid2</field>
+ <field name="hits">12</field>
  <field name="model.locale">en-us</field>
  <field name="collapse.summary">short-summary</field>
  <field name="collapsefield">doc_id</field>


### PR DESCRIPTION
This makes hybrid2 the default rank-profile, it scores 5 nDCG@10 points better than the previous and outperforms reciprocal rank fusion /hybrid3 with 10 points

```
Hybrid {nDCG@10: 0.670331212965862}
Hybrid2 {nDCG@10: 0.7290411765280541}
Hybrid3 {nDCG@10: 0.6423798114562088}
BM25 {nDCG@10: 0.6348525227398569}
Semantic {nDCG@10: 0.5708783894471428}
```