### PR TITLE
Remove python-cache

### DIFF
--- a/.github/workflows/deploy-from-pyvespa.yaml
+++ b/.github/workflows/deploy-from-pyvespa.yaml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-          cache: "pip" # caching pip dependencies
       # Install dependencies
       - name: Install dependencies
         run: pip install pyvespa vespacli


### PR DESCRIPTION
If cache is enabled, this action expects a `pyproject.toml` or similar file. 