### PR TITLE
Remove unused field in fieldset in slack_message schema

### DIFF
--- a/src/main/application/schemas/slack_message.sd
+++ b/src/main/application/schemas/slack_message.sd
@@ -39,7 +39,7 @@ schema slack_message {
     }
 
     fieldset default {
-        fields: text, thread_id
+        fields: text
     }
 
     document-summary short-summary {


### PR DESCRIPTION
This pr aims to remove the warnings produced by slack_message schema.

Additionally, threadId should not be used in ranking.
