### PR TITLE
Adds `doc_id` field to thread query profile

### DIFF
--- a/src/main/java/ai/vespa/cloud/docsearch/ThreadSearcher.java
+++ b/src/main/java/ai/vespa/cloud/docsearch/ThreadSearcher.java
@@ -35,12 +35,17 @@ public class ThreadSearcher extends Searcher {
 
         Result newResult = new Result(query);
         for (Hit group : threadIdGroupList) {
-            HitGroup hitGroup = new HitGroup(getThreadId((Group)group), group.getRelevance());
+            var threadId = getThreadId((Group)group);
+
+            HitGroup hitGroup = new HitGroup(threadId, group.getRelevance());
             for (Hit hitList : (HitGroup) group) {
                 for (Hit hit : (HitList) hitList) {
                     hitGroup.add(hit);
                 }
             }
+
+            hitGroup.setField("doc_id", threadId);
+
             newResult.hits().add(hitGroup);
         }
         return newResult;


### PR DESCRIPTION
To test the retrieval of Slack threads using `eval/evaluate_ranking.py`, this pr adds `doc_id` to the threads.