### PR TITLE
use configuration in services.xml

### DIFF
--- a/src/main/application/schemas/paragraph.sd
+++ b/src/main/application/schemas/paragraph.sd
@@ -62,16 +62,17 @@ schema paragraph {
     }
 
     field embedding type tensor<float>(x[384]) {
-        indexing: "passage: " . (input title || "") . " " . (input content || "") | embed | attribute
+        indexing: (input title || "") . " " . (input content || "") | embed embedder | attribute
         attribute {
             distance-metric: angular
         }
     }
 
     field question_embedding type tensor<float>(q{}, x[384]) {
+         # the query config to be moved to services.xml
          indexing {
             input questions |
-                for_each { "query: " . _ } | embed | attribute
+                for_each { "query: " . _ } | embed embedder | attribute
          }
 
          attribute {

--- a/src/main/application/services.xml
+++ b/src/main/application/services.xml
@@ -10,6 +10,10 @@
         <component id="embedder" type="hugging-face-embedder">
             <transformer-model path="model/model.onnx"/>
             <tokenizer-model path="model/tokenizer.json"/>
+            <prepend>
+                <!--query>query:</query--> <!-- for now, this is added to queries elsewhere -->
+                <document>passage: </document>
+            </prepend>
         </component>
         <document-processing>
             <chain id="default">


### PR DESCRIPTION
- minor cleanup, better if we keep the embedded config in services.xml
- make embedder id explicit - makes it easier to add other models for later experimentation (we often us this app as an example for others)

We could configure the query prepend config too, but I am not sure if there are more places to change than in paragraph.sd