### PR TITLE
Add user id to slack message

### DIFF
--- a/src/main/application/schemas/slack_message.sd
+++ b/src/main/application/schemas/slack_message.sd
@@ -37,7 +37,7 @@ schema slack_message {
             indexing: summary
         }
 
-        field user_id_hash type string {
+        field user_id type string {
             indexing: summary
         }
 

--- a/src/main/application/schemas/slack_message.sd
+++ b/src/main/application/schemas/slack_message.sd
@@ -37,6 +37,10 @@ schema slack_message {
             indexing: summary
         }
 
+        field user_id_hash type string {
+            indexing: summary
+        }
+
     }
 
     field text_embedding type tensor<float>(x[384]) {


### PR DESCRIPTION
Because of GDPR we are required to keep track of which user created each message, so that we can delete them if asked to.