### PR TITLE
Revert "Wait for expected document count, take 2"

### DIFF
--- a/src/test/java/ai/vespa/cloud/docsearch/VespaDocStagingSetup.java
+++ b/src/test/java/ai/vespa/cloud/docsearch/VespaDocStagingSetup.java
@@ -29,7 +29,6 @@ public class VespaDocStagingSetup {
         assertEquals(5, ids.size(), "test-documents.json should have 5 documents");
 
         String allQuery = "select * from sources * where sddocname contains \"doc\"";
-        tester.waitUntilBackendUp(allQuery);
         tester.verifyQueryResults(ids, allQuery, "5s"); // Use a high timeout for first query
 
         String accessQuery = "select * from sources * where content contains \"access\"";

--- a/src/test/java/ai/vespa/cloud/docsearch/VespaDocTester.java
+++ b/src/test/java/ai/vespa/cloud/docsearch/VespaDocTester.java
@@ -110,15 +110,6 @@ class VespaDocTester {
         return ids;
     }
 
-    void waitUntilBackendUp(String query) throws IOException {
-        String result = search(query, "1s");
-        int retries = 0;
-        while (getNumSearchResults(result) < 5 && retries < 30) {
-            try { Thread.sleep(1000); } catch (InterruptedException e) { throw new RuntimeException(e); }
-            retries++;
-        }
-    }
-
     void verifyQueryResults(Collection<DocumentId> expectedIds, String query, String timeout) throws IOException {
         String result = search(query, timeout);
         assertEquals(expectedIds.size(), getNumSearchResults(result));


### PR DESCRIPTION
Reverts vespa-cloud/vespa-documentation-search#186

Nah, didn't work in all cases now either, need to find a way to test this somewhere else first.