### PR TITLE
add type resolving (to fix unpack_bits)

### DIFF
--- a/src/test/java/ai/vespa/cloud/playground/ExpressionEvaluatorTest.java
+++ b/src/test/java/ai/vespa/cloud/playground/ExpressionEvaluatorTest.java
@@ -81,7 +81,36 @@ public class ExpressionEvaluatorTest {
         assertEquals(expected.get("value").get("literal").asText(), result.get("value").get("literal").asText());
     }
 
+    @Test
+    public void requireThatUnpackBitsCanBeEvaluated() throws IOException {
+        String evaluateJson = String.join("\n",
+                "{",
+                "   \"expression\": \"unpack_bits(attribute(colbert))\",",
+                "   \"arguments\": [",
+                "       {",
+                "           \"name\": \"attribute(colbert)\",",
+                "           \"type\": \"tensor<int8>(dt{},x[1])\",",
+                "           \"value\": \"tensor<int8>(dt{}, x[1]):{0:[-83]}\"",
+                "       }",
+                "   ]",
+                "}");
+        String expectedJson = String.join("\n",
+                "{",
+                "   \"type\": \"tensor<float>(dt{},x[8])\",",
+                "   \"value\": {",
+                "       \"literal\": \"tensor<float>(dt{},x[8]):{0:[1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0]}\",",
+                "       \"cells\": [\"whatever\"]",
+                "   }",
+                "}");
+
+        String resultJson = ExpressionEvaluator.evaluate(evaluateJson);
+
+        ObjectMapper m = new ObjectMapper();
+        JsonNode result = m.readTree(resultJson);
+        JsonNode expected = m.readTree(expectedJson);
+
+        assertEquals(expected.get("type").asText(), result.get("type").asText());
+        assertEquals(expected.get("value").get("literal").asText(), result.get("value").get("literal").asText());
+    }
+
 }
-
-
-

--- a/src/test/java/ai/vespa/cloud/playground/ProtonExpressionEvaluatorTest.java
+++ b/src/test/java/ai/vespa/cloud/playground/ProtonExpressionEvaluatorTest.java
@@ -1,0 +1,73 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package ai.vespa.cloud.playground;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.searchlib.rankingexpression.evaluation.DoubleValue;
+import com.yahoo.searchlib.rankingexpression.evaluation.MapContext;
+import com.yahoo.searchlib.rankingexpression.evaluation.TensorValue;
+import com.yahoo.searchlib.rankingexpression.evaluation.Value;
+import com.yahoo.searchlib.rankingexpression.parser.ParseException;
+import com.yahoo.tensor.Tensor;
+import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ProtonExpressionEvaluatorTest {
+
+ // @Test
+    public void requireThatTensorExpressionCanBeEvaluated() throws Exception {
+        String json =
+                """
+                   [ { "name": "t1",
+                       "cell": 1,
+                       "verbose": false,
+                       "expr": "tensor(x{}):{{x:0}:1,{x:1}:2}" },
+                     { "name": "t2",
+                       "cell": 2,
+                       "verbose": false,
+                       "expr": "tensor(x{}):{{x:0}:2,{x:1}:3}" },
+                     { "name": "out",
+                       "cell": 3,
+                       "verbose": false,
+                       "expr": "t1 * t2" } ]
+                """;
+        String v = ProtonExpressionEvaluator.evaluate(json);
+
+        ObjectMapper m = new ObjectMapper();
+        JsonNode root = m.readTree(v);
+        assertNotNull(root);
+        System.err.println("Result of simple multiplication: " + root.toPrettyString());
+    }
+
+ // @Test
+    public void requireThatUnpackBitsCanBeEvaluated() throws Exception {
+        String json =
+                """
+                   [
+                       { "name": "attribute(colbert)",
+                         "cell": 3,
+                         "verbose": false,
+                         "expr": "tensor<int8>(dt{}, x[2]):{ 0:[-83,107], foo:[119,170] }"
+                       },
+                       { "name": "unpack",
+                         "cell": 42,
+                         "verbose": true,
+                         "expr": "unpack_bits(attribute(colbert))"
+                       }
+                   ]
+                """;
+        String v = ProtonExpressionEvaluator.evaluate(json);
+
+        ObjectMapper m = new ObjectMapper();
+        JsonNode root = m.readTree(v);
+        assertNotNull(root);
+        System.err.println("Result with unpack_bits: " + root.toPrettyString());
+    }
+
+
+}


### PR DESCRIPTION
Note: new unit tests are disabled, because they require the vespa-eval-expr binary installed.  May be enabled manually to aid debugging in the future.

@bjorncs or @havardpe please review
