### PR TITLE
Revert "set up grouped in enclave"

### DIFF
--- a/src/main/application/services.xml
+++ b/src/main/application/services.xml
@@ -77,11 +77,9 @@
             <document mode="index" type="purchase"/>
             <document mode="index" type="code_snippet"/>
         </documents>
-        <nodes count="2" deploy:instance="enclave">
-            <resources vcpu="2" memory="8Gb" disk="32Gb" architecture="x86_64"/>
-        </nodes>
-        <nodes groups="2" group-size="2" deploy:instance="cloud-enclave" deploy:cloud="aws">
-            <resources vcpu="2" memory="8Gb" disk="118Gb" storage-type="local"/>
+        <nodes count="2">
+            <resources vcpu="2" memory="8Gb" disk="32Gb" architecture="x86_64" deploy:instance="enclave" />
+            <resources vcpu="2" memory="8Gb" disk="118Gb" storage-type="local" deploy:instance="cloud-enclave" deploy:cloud="aws"/>
         </nodes>
     </content>
 </services>


### PR DESCRIPTION
Reverts vespa-cloud/vespa-documentation-search#250


Deployment failed: Invalid application: redundancy-one:
	content cluster 'documentation' has redundancy 1, which will cause it to lose data if a node fails. This requires an override on first deployment in a production zone
To allow this add <allow until='yyyy-mm-dd'>redundancy-one</allow> to validation-overrides.xml, see https://docs.vespa.ai/en/reference/applications/validation-overrides.html
minimum-node-count:
	content cluster 'documentation' has less than 2 nodes, which may cause service disruption during node failures or upgrades. This requires an override on first deployment in a production zone
To allow this add <allow until='yyyy-mm-dd'>minimum-node-count</allow> to validation-overrides.xml, see https://docs.vespa.ai/en/reference/applications/validation-overrides.html